### PR TITLE
use setShowGrid instead of stylesheet to hide grid lines

### DIFF
--- a/asset_browser/_browser.py
+++ b/asset_browser/_browser.py
@@ -131,7 +131,7 @@ class MyWindow(QtWidgets.QDialog):
 
         self.tableView.setSelectionBehavior(QtWidgets.QAbstractItemView.SelectRows)
         self.tableView.setSelectionMode(QtWidgets.QAbstractItemView.ExtendedSelection)
-        self.tableView.setStyleSheet("QTableView { gridline-color: rgba(0,0,0,0.0); }")
+        self.tableView.setShowGrid(False)
 
         self.resize(330, 420)
         self.show()


### PR DESCRIPTION
I realized in last screenshot, grid lines are visible, when row is highlighted

![image](https://github.com/user-attachments/assets/3bd5f679-f92f-4e22-be6a-c67a85788895)
